### PR TITLE
Add 65 tests covering previously untested code paths (78% → 87%)

### DIFF
--- a/tests/unit/test_agent_leader.py
+++ b/tests/unit/test_agent_leader.py
@@ -1,0 +1,64 @@
+"""tests/unit/test_agent_leader.py — AgentLeader 白名单约束验证。"""
+
+from __future__ import annotations
+
+import pytest
+
+from harness.runners.agent_leader import AgentLeader
+from harness.runners.base import AbstractRunner, RunnerResult
+
+
+class SpyRunner(AbstractRunner):
+    """记录最近一次调用参数的 runner。"""
+
+    def __init__(self) -> None:
+        self.last_system_prompt: str | None = None
+        self.last_prompt: str | None = None
+        self.last_kwargs: dict = {}
+
+    async def execute(self, prompt, *, system_prompt, session_id, **kwargs) -> RunnerResult:
+        self.last_prompt = prompt
+        self.last_system_prompt = system_prompt
+        self.last_kwargs = kwargs
+        return RunnerResult(text="ok", tokens_used=5, session_id=None)
+
+
+class TestAgentLeader:
+    @pytest.mark.asyncio
+    async def test_appends_whitelist_to_system_prompt(self) -> None:
+        spy = SpyRunner()
+        leader = AgentLeader(agents=["agent-a", "agent-b"], runner=spy)
+
+        await leader.execute("do something", system_prompt="base sp", session_id=None)
+
+        assert spy.last_system_prompt is not None
+        assert "base sp" in spy.last_system_prompt
+        assert "agent-a" in spy.last_system_prompt
+        assert "agent-b" in spy.last_system_prompt
+        assert "白名单" in spy.last_system_prompt
+
+    @pytest.mark.asyncio
+    async def test_passes_prompt_and_session(self) -> None:
+        spy = SpyRunner()
+        leader = AgentLeader(agents=["x"], runner=spy)
+
+        await leader.execute("hello", system_prompt="sp", session_id="s123")
+
+        assert spy.last_prompt == "hello"
+
+    @pytest.mark.asyncio
+    async def test_returns_runner_result(self) -> None:
+        spy = SpyRunner()
+        leader = AgentLeader(agents=["a"], runner=spy)
+
+        result = await leader.execute("q", system_prompt="", session_id=None)
+
+        assert result.text == "ok"
+        assert result.tokens_used == 5
+
+    @pytest.mark.asyncio
+    async def test_default_runner_is_claude_cli(self) -> None:
+        from harness.runners.claude_cli import ClaudeCliRunner
+
+        leader = AgentLeader(agents=["a"])
+        assert isinstance(leader._runner, ClaudeCliRunner)

--- a/tests/unit/test_classify_error.py
+++ b/tests/unit/test_classify_error.py
@@ -1,0 +1,120 @@
+"""tests/unit/test_classify_error.py — _classify_error 所有分支覆盖。"""
+
+from harness._internal.exceptions import _classify_error
+
+
+class TestClassifyErrorNetwork:
+    def test_socks_missing(self) -> None:
+        cat, hint = _classify_error("PySocksError: SOCKS support is missing")
+        assert cat == "网络错误 [SOCKS代理]"
+        assert "uv add" in hint
+
+    def test_socks_missing_variant(self) -> None:
+        cat, _ = _classify_error("Missing socks module for proxy")
+        assert cat == "网络错误 [SOCKS代理]"
+
+    def test_proxy_error(self) -> None:
+        cat, hint = _classify_error("ProxyError: cannot connect")
+        assert cat == "网络错误 [代理]"
+        assert "unset" in hint
+
+    def test_proxy_keyword(self) -> None:
+        cat, _ = _classify_error("proxy connection failed")
+        assert cat == "网络错误 [代理]"
+
+    def test_connection_pool(self) -> None:
+        cat, _ = _classify_error("urllib3 ConnectionPool failed")
+        assert cat == "网络错误 [连接超时]"
+
+    def test_max_retries_exceeded(self) -> None:
+        cat, hint = _classify_error("Max retries exceeded with url")
+        assert cat == "网络错误 [连接超时]"
+        assert "网络" in hint
+
+    def test_timeout(self) -> None:
+        cat, hint = _classify_error("Request timed out after 30s")
+        assert cat == "超时"
+        assert "TaskConfig" in hint
+
+    def test_connection_refused(self) -> None:
+        cat, hint = _classify_error("ConnectionRefusedError: [Errno 111]")
+        assert cat == "网络错误 [连接被拒]"
+        assert "服务" in hint
+
+    def test_connection_refused_phrase(self) -> None:
+        cat, _ = _classify_error("Connection refused on port 8080")
+        assert cat == "网络错误 [连接被拒]"
+
+
+class TestClassifyErrorImport:
+    def test_module_not_found_with_name(self) -> None:
+        cat, hint = _classify_error("ModuleNotFoundError: No module named 'pandas'")
+        assert cat == "依赖缺失"
+        assert "pandas" in hint
+        assert "uv add" in hint
+
+    def test_module_not_found_lowercase(self) -> None:
+        """lowercase 'no module named' 匹配分类，但 split 用 title case 提取包名。"""
+        cat, hint = _classify_error("no module named 'requests'")
+        assert cat == "依赖缺失"
+        # 大小写不匹配 split("No module named")，回退到通用提示
+        assert "pyproject.toml" in hint
+
+    def test_module_not_found_no_name(self) -> None:
+        """modulenotfounderror 但无 'No module named' 片段。"""
+        cat, hint = _classify_error("ModuleNotFoundError: something else")
+        assert cat == "依赖缺失"
+        assert "pyproject.toml" in hint
+
+    def test_import_error(self) -> None:
+        cat, hint = _classify_error("ImportError: cannot import name 'foo'")
+        assert cat == "导入错误"
+        assert "安装" in hint
+
+
+class TestClassifyErrorAuth:
+    def test_401(self) -> None:
+        cat, hint = _classify_error("HTTP 401 Unauthorized")
+        assert cat == "认证失败"
+        assert "API Key" in hint
+
+    def test_unauthorized_word(self) -> None:
+        cat, _ = _classify_error("authentication required for this endpoint")
+        assert cat == "认证失败"
+
+    def test_403(self) -> None:
+        cat, hint = _classify_error("HTTP 403 Forbidden")
+        assert cat == "权限不足"
+        assert "权限" in hint
+
+    def test_forbidden_word(self) -> None:
+        cat, _ = _classify_error("Access forbidden")
+        assert cat == "权限不足"
+
+
+class TestClassifyErrorFile:
+    def test_file_not_found(self) -> None:
+        cat, hint = _classify_error("FileNotFoundError: /tmp/missing.txt")
+        assert cat == "文件不存在"
+        assert "路径" in hint
+
+    def test_no_such_file(self) -> None:
+        cat, _ = _classify_error("No such file or directory: /tmp/x")
+        assert cat == "文件不存在"
+
+    def test_permission_error(self) -> None:
+        cat, hint = _classify_error("PermissionError: [Errno 13]")
+        assert cat == "权限错误"
+        assert "权限" in hint
+
+
+class TestClassifyErrorMisc:
+    def test_prompt_callable(self) -> None:
+        cat, hint = _classify_error("Prompt callable raised: IndexError")
+        assert cat == "Prompt 构建失败"
+        assert "prompt" in hint
+
+    def test_fallback(self) -> None:
+        cat, hint = _classify_error("some completely unknown error")
+        assert cat == "执行错误"
+        assert "Task" in hint or "依赖" in hint

--- a/tests/unit/test_claude_cli_runner.py
+++ b/tests/unit/test_claude_cli_runner.py
@@ -1,0 +1,250 @@
+"""tests/unit/test_claude_cli_runner.py — ClaudeCliRunner 单元测试（mock subprocess）。"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from harness._internal.exceptions import ClaudeNotFoundError
+from harness.runners.claude_cli import ClaudeCliRunner, PermissionMode, _ENV_VARS_TO_REMOVE
+
+
+class TestPermissionMode:
+    def test_values(self) -> None:
+        assert PermissionMode.BYPASS == "bypassPermissions"
+        assert PermissionMode.DEFAULT == "default"
+        assert PermissionMode.PLAN == "plan"
+
+
+class TestGetSubprocessEnv:
+    def test_removes_claude_vars(self) -> None:
+        runner = ClaudeCliRunner()
+        with patch.dict(os.environ, {"CLAUDECODE": "1", "CLAUDE_CODE": "1", "PATH": "/usr/bin"}):
+            env = runner._get_subprocess_env()
+            assert "CLAUDECODE" not in env
+            assert "CLAUDE_CODE" not in env
+            assert "PATH" in env
+
+    def test_keeps_normal_vars(self) -> None:
+        runner = ClaudeCliRunner()
+        with patch.dict(os.environ, {"MY_VAR": "hello"}, clear=False):
+            env = runner._get_subprocess_env()
+            assert env["MY_VAR"] == "hello"
+
+
+class TestEnsureClaude:
+    @pytest.mark.asyncio
+    async def test_claude_not_found(self) -> None:
+        runner = ClaudeCliRunner()
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(ClaudeNotFoundError):
+                await runner._ensure_claude()
+
+    @pytest.mark.asyncio
+    async def test_cached_not_found_raises(self) -> None:
+        """第二次调用直接从缓存抛 ClaudeNotFoundError。"""
+        runner = ClaudeCliRunner()
+        with patch("shutil.which", return_value=None):
+            with pytest.raises(ClaudeNotFoundError):
+                await runner._ensure_claude()
+        # 第二次不调用 which，直接从缓存抛
+        with pytest.raises(ClaudeNotFoundError):
+            await runner._ensure_claude()
+
+    @pytest.mark.asyncio
+    async def test_claude_found(self) -> None:
+        runner = ClaudeCliRunner()
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"1.0.0", b""))
+
+        with patch("shutil.which", return_value="/usr/bin/claude"), \
+             patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            path = await runner._ensure_claude()
+            assert path == "/usr/bin/claude"
+
+    @pytest.mark.asyncio
+    async def test_cached_found(self) -> None:
+        runner = ClaudeCliRunner()
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"1.0.0", b""))
+
+        with patch("shutil.which", return_value="/usr/bin/claude"), \
+             patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            await runner._ensure_claude()
+
+        # 第二次应直接返回缓存
+        path = await runner._ensure_claude()
+        assert path == "/usr/bin/claude"
+
+    @pytest.mark.asyncio
+    async def test_version_check_failure_logs_warning(self, capsys) -> None:
+        runner = ClaudeCliRunner()
+        with patch("shutil.which", return_value="/usr/bin/claude"), \
+             patch("asyncio.create_subprocess_exec", side_effect=OSError("fail")):
+            path = await runner._ensure_claude()
+            assert path == "/usr/bin/claude"
+        captured = capsys.readouterr()
+        assert "Warning" in captured.out
+
+
+class TestExecute:
+    @pytest.mark.asyncio
+    async def test_basic_execution(self) -> None:
+        """基本执行流程：构建 args、启动子进程、解析输出。"""
+        runner = ClaudeCliRunner()
+        runner._checked = True
+        runner._claude_path = "/usr/bin/claude"
+
+        # mock stdout 返回一条 stream-json 结果行
+        import json
+        result_msg = json.dumps({
+            "type": "result",
+            "result": "hello world",
+            "session_id": "sess-1",
+            "cost_usd": 0.01,
+            "duration_ms": 100,
+            "total_cost_usd": 0.01,
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        })
+
+        mock_stdout = AsyncMock()
+        mock_stdout.__aiter__ = lambda self: self
+        mock_stdout.__anext__ = AsyncMock(side_effect=[
+            (result_msg + "\n").encode(),
+            StopAsyncIteration(),
+        ])
+
+        mock_stderr = AsyncMock()
+        mock_stderr.read = AsyncMock(return_value=b"")
+
+        mock_proc = AsyncMock()
+        mock_proc.stdout = mock_stdout
+        mock_proc.stderr = mock_stderr
+        mock_proc.wait = AsyncMock(return_value=0)
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch.object(runner, "_get_subprocess_env", return_value={"PATH": "/usr/bin"}):
+            result = await runner.execute(
+                "test prompt",
+                system_prompt="test sp",
+                session_id=None,
+            )
+
+        assert result.text == "hello world"
+        assert result.session_id == "sess-1"
+
+    @pytest.mark.asyncio
+    async def test_session_id_passed_as_resume(self) -> None:
+        """session_id 被传为 --resume 参数。"""
+        runner = ClaudeCliRunner()
+        runner._checked = True
+        runner._claude_path = "/usr/bin/claude"
+
+        captured_args = []
+
+        async def mock_create(*args, **kwargs):
+            captured_args.extend(args)
+            mock_stdout = AsyncMock()
+            mock_stdout.__aiter__ = lambda self: self
+            mock_stdout.__anext__ = AsyncMock(side_effect=StopAsyncIteration())
+            mock_stderr = AsyncMock()
+            mock_stderr.read = AsyncMock(return_value=b"")
+            proc = AsyncMock()
+            proc.stdout = mock_stdout
+            proc.stderr = mock_stderr
+            proc.wait = AsyncMock(return_value=0)
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_create), \
+             patch.object(runner, "_get_subprocess_env", return_value={}):
+            await runner.execute(
+                "prompt",
+                system_prompt="",
+                session_id="my-session",
+            )
+
+        assert "--resume" in captured_args
+        assert "my-session" in captured_args
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_logs_warning(self, caplog) -> None:
+        """非零退出码时记录 stderr 到日志。"""
+        import logging
+
+        runner = ClaudeCliRunner()
+        runner._checked = True
+        runner._claude_path = "/usr/bin/claude"
+
+        mock_stdout = AsyncMock()
+        mock_stdout.__aiter__ = lambda self: self
+        mock_stdout.__anext__ = AsyncMock(side_effect=StopAsyncIteration())
+
+        mock_stderr = AsyncMock()
+        mock_stderr.read = AsyncMock(return_value=b"some error occurred")
+
+        mock_proc = AsyncMock()
+        mock_proc.stdout = mock_stdout
+        mock_proc.stderr = mock_stderr
+        mock_proc.wait = AsyncMock(return_value=1)
+        mock_proc.returncode = 1
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc), \
+             patch.object(runner, "_get_subprocess_env", return_value={}), \
+             caplog.at_level(logging.WARNING, logger="harness.runners.claude_cli"):
+            await runner.execute("p", system_prompt="", session_id=None)
+
+        assert "some error occurred" in caplog.text
+
+
+class TestTerminate:
+    @pytest.mark.asyncio
+    async def test_sigterm_then_wait(self) -> None:
+        """正常关闭：SIGTERM 后进程退出。"""
+        runner = ClaudeCliRunner()
+        mock_proc = MagicMock()
+        mock_proc.send_signal = MagicMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+        mock_proc.kill = MagicMock()
+
+        await runner._terminate(mock_proc)
+
+        mock_proc.send_signal.assert_called_once_with(signal.SIGTERM)
+
+    @pytest.mark.asyncio
+    async def test_sigterm_timeout_then_sigkill(self) -> None:
+        """SIGTERM 超时后发送 SIGKILL。"""
+        runner = ClaudeCliRunner()
+        mock_proc = MagicMock()
+        mock_proc.send_signal = MagicMock()
+
+        call_count = 0
+
+        async def slow_wait():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # 第一次 wait（SIGTERM 后）超时
+                await asyncio.sleep(100)
+            # 第二次 wait（SIGKILL 后）立即返回
+
+        mock_proc.wait = slow_wait
+        mock_proc.kill = MagicMock()
+
+        await runner._terminate(mock_proc)
+
+        mock_proc.kill.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_process_already_exited(self) -> None:
+        """进程已退出时不抛异常。"""
+        runner = ClaudeCliRunner()
+        mock_proc = MagicMock()
+        mock_proc.send_signal = MagicMock(side_effect=ProcessLookupError)
+
+        await runner._terminate(mock_proc)  # 不抛异常

--- a/tests/unit/test_executor_edge_cases.py
+++ b/tests/unit/test_executor_edge_cases.py
@@ -1,0 +1,209 @@
+"""tests/unit/test_executor_edge_cases.py — Executor 缺失路径覆盖。"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+import pytest
+
+from harness._internal.exceptions import TaskFailedError
+from harness._internal.executor import (
+    _emit_separator,
+    execute_function_task,
+    execute_llm_task,
+    execute_shell_task,
+)
+from harness._internal.session import SessionManager
+from harness.runners.base import AbstractRunner, RunnerResult
+from harness.task import FunctionTask, LLMTask, Result, ShellTask, TaskConfig
+
+
+# ---------------------------------------------------------------------------
+# LLMTask 超时
+# ---------------------------------------------------------------------------
+
+
+class SlowRunner(AbstractRunner):
+    """模拟超时的 runner。"""
+
+    async def execute(self, prompt, *, system_prompt, session_id, **kwargs) -> RunnerResult:
+        await asyncio.sleep(100)
+        return RunnerResult(text="ok", tokens_used=0, session_id=None)
+
+
+class TestLLMTaskTimeout:
+    @pytest.mark.asyncio
+    async def test_timeout_marks_session_broken(self) -> None:
+        """LLMTask 超时后 session 应被标记为 broken。"""
+        sm = SessionManager()
+        task = LLMTask(
+            prompt="slow",
+            config=TaskConfig(max_retries=0, timeout=0.01),
+        )
+        with pytest.raises(TaskFailedError) as exc_info:
+            await execute_llm_task(
+                task, "0", [], "run-1",
+                harness_system_prompt="",
+                harness_runner=SlowRunner(),
+                harness_config=None,
+                session_manager=sm,
+                memory_injection="",
+            )
+        assert "timed out" in exc_info.value.error
+
+
+# ---------------------------------------------------------------------------
+# FunctionTask env_overrides
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionTaskEnvOverrides:
+    @pytest.mark.asyncio
+    async def test_env_overrides_applied_and_restored(self) -> None:
+        """env_overrides 在执行期间生效，执行后恢复。"""
+        original = os.environ.get("HARNESS_TEST_VAR")
+
+        captured = {}
+
+        def fn(results):
+            captured["var"] = os.environ.get("HARNESS_TEST_VAR")
+            return "ok"
+
+        task = FunctionTask(fn=fn)
+        await execute_function_task(
+            task, "0", [], "run-1",
+            harness_config=None,
+            env_overrides={"HARNESS_TEST_VAR": "test_value"},
+        )
+
+        assert captured["var"] == "test_value"
+        assert os.environ.get("HARNESS_TEST_VAR") == original
+
+    @pytest.mark.asyncio
+    async def test_env_overrides_remove_var(self) -> None:
+        """env_overrides 值为空字符串时删除环境变量。"""
+        os.environ["HARNESS_TEST_REMOVE"] = "exists"
+        captured = {}
+
+        def fn(results):
+            captured["var"] = os.environ.get("HARNESS_TEST_REMOVE")
+            return "ok"
+
+        task = FunctionTask(fn=fn)
+        try:
+            await execute_function_task(
+                task, "0", [], "run-1",
+                harness_config=None,
+                env_overrides={"HARNESS_TEST_REMOVE": ""},
+            )
+            assert captured["var"] is None
+        finally:
+            # 确保恢复
+            assert os.environ.get("HARNESS_TEST_REMOVE") == "exists"
+            os.environ.pop("HARNESS_TEST_REMOVE", None)
+
+    @pytest.mark.asyncio
+    async def test_env_overrides_restored_on_exception(self) -> None:
+        """fn 抛异常时 env_overrides 仍然被恢复。"""
+        original = os.environ.get("HARNESS_TEST_ERR")
+
+        def fn(results):
+            raise RuntimeError("boom")
+
+        task = FunctionTask(
+            fn=fn,
+            config=TaskConfig(max_retries=0),
+        )
+        with pytest.raises(TaskFailedError):
+            await execute_function_task(
+                task, "0", [], "run-1",
+                harness_config=None,
+                env_overrides={"HARNESS_TEST_ERR": "temp"},
+            )
+
+        assert os.environ.get("HARNESS_TEST_ERR") == original
+
+
+# ---------------------------------------------------------------------------
+# ShellTask 超时
+# ---------------------------------------------------------------------------
+
+
+class TestShellTaskTimeout:
+    @pytest.mark.asyncio
+    async def test_shell_timeout_kills_process(self) -> None:
+        """ShellTask 超时后进程被 kill。"""
+        task = ShellTask(
+            cmd="sleep 100",
+            config=TaskConfig(max_retries=0, timeout=0.05),
+        )
+        with pytest.raises(TaskFailedError) as exc_info:
+            await execute_shell_task(
+                task, "0", [], "run-1",
+                harness_config=None,
+            )
+        assert "timed out" in exc_info.value.error
+
+
+class TestShellTaskEnvOverrides:
+    @pytest.mark.asyncio
+    async def test_env_overrides_passed_to_subprocess(self) -> None:
+        """env_overrides 传递到 shell 子进程。"""
+        task = ShellTask(cmd="echo $HARNESS_SHELL_TEST")
+        result = await execute_shell_task(
+            task, "0", [], "run-1",
+            harness_config=None,
+            env_overrides={"HARNESS_SHELL_TEST": "hello_env"},
+        )
+        assert "hello_env" in result.output
+
+    @pytest.mark.asyncio
+    async def test_task_env_passed_to_subprocess(self) -> None:
+        """task.env 传递到 shell 子进程。"""
+        task = ShellTask(
+            cmd="echo $HARNESS_TASK_ENV",
+            env={"HARNESS_TASK_ENV": "from_task"},
+        )
+        result = await execute_shell_task(
+            task, "0", [], "run-1",
+            harness_config=None,
+        )
+        assert "from_task" in result.output
+
+    @pytest.mark.asyncio
+    async def test_env_overrides_override_task_env(self) -> None:
+        """env_overrides 优先级高于 task.env。"""
+        task = ShellTask(
+            cmd="echo $HARNESS_PRIORITY_TEST",
+            env={"HARNESS_PRIORITY_TEST": "from_task"},
+        )
+        result = await execute_shell_task(
+            task, "0", [], "run-1",
+            harness_config=None,
+            env_overrides={"HARNESS_PRIORITY_TEST": "from_harness"},
+        )
+        assert "from_harness" in result.output
+
+
+# ---------------------------------------------------------------------------
+# _emit_separator 回调异常
+# ---------------------------------------------------------------------------
+
+
+class TestEmitSeparator:
+    def test_callback_exception_suppressed(self) -> None:
+        """stream_callback 抛异常不影响执行。"""
+
+        def bad_cb(text: str) -> None:
+            raise RuntimeError("callback error")
+
+        # 不应抛异常
+        _emit_separator("0", "llm", bad_cb, None)
+
+    def test_callback_receives_separator(self) -> None:
+        captured = []
+        _emit_separator("1", "function", captured.append, None)
+        assert len(captured) == 1
+        assert "Task 1" in captured[0]
+        assert "function" in captured[0]

--- a/tests/unit/test_parallel_edge_cases.py
+++ b/tests/unit/test_parallel_edge_cases.py
@@ -1,0 +1,253 @@
+"""tests/unit/test_parallel_edge_cases.py — Parallel 缺失路径覆盖。"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from harness._internal.exceptions import TaskFailedError
+from harness._internal.parallel import (
+    _run_all_or_nothing,
+    _run_best_effort,
+    _task_type_str,
+    execute_parallel,
+)
+from harness._internal.session import SessionManager
+from harness.runners.base import AbstractRunner, RunnerResult
+from harness.task import FunctionTask, LLMTask, Parallel, PollingTask, Result, ShellTask, TaskConfig
+
+
+class MockRunner(AbstractRunner):
+    async def execute(self, prompt, *, system_prompt, session_id, **kwargs) -> RunnerResult:
+        return RunnerResult(text="ok", tokens_used=0, session_id=None)
+
+
+def make_result(index: str = "0") -> Result:
+    return Result(
+        task_index=index, task_type="llm", output="x",
+        raw_text="x", tokens_used=0, duration_seconds=0.0,
+        success=True, error=None,
+    )
+
+
+def make_parallel_kwargs(**overrides):
+    defaults = dict(
+        run_id="run-1",
+        harness_system_prompt="",
+        harness_runner=MockRunner(),
+        harness_config=None,
+        session_manager=SessionManager(),
+        memory_injection="",
+        storage=None,
+        is_new_session=False,
+    )
+    defaults.update(overrides)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# _run_all_or_nothing: task cancellation & non-TaskFailedError wrapping
+# ---------------------------------------------------------------------------
+
+
+class TestAllOrNothingCancellation:
+    @pytest.mark.asyncio
+    async def test_failure_cancels_remaining_tasks(self) -> None:
+        """一个任务失败时，其余任务应被取消。"""
+        slow_cancelled = False
+
+        async def slow_coro():
+            nonlocal slow_cancelled
+            try:
+                await asyncio.sleep(100)
+            except asyncio.CancelledError:
+                slow_cancelled = True
+                raise
+            return make_result("0.0")
+
+        async def fail_coro():
+            raise TaskFailedError("run-1", "0.1", "function", "boom")
+
+        with pytest.raises(TaskFailedError):
+            await _run_all_or_nothing(
+                [slow_coro(), fail_coro()],
+                "run-1",
+                0,
+            )
+        # 给取消一点时间完成
+        await asyncio.sleep(0.05)
+        assert slow_cancelled
+
+    @pytest.mark.asyncio
+    async def test_non_task_failed_error_wrapped(self) -> None:
+        """非 TaskFailedError 应被包装为 TaskFailedError。"""
+
+        async def fail_coro():
+            raise ValueError("unexpected")
+
+        async def ok_coro():
+            return make_result("0.0")
+
+        with pytest.raises(TaskFailedError) as exc_info:
+            await _run_all_or_nothing(
+                [ok_coro(), fail_coro()],
+                "run-1",
+                0,
+            )
+        assert "unexpected" in exc_info.value.error
+
+
+# ---------------------------------------------------------------------------
+# _run_best_effort: exception wrapping
+# ---------------------------------------------------------------------------
+
+
+class TestBestEffortErrorWrapping:
+    @pytest.mark.asyncio
+    async def test_failed_tasks_marked_as_failed(self) -> None:
+        """失败的 task 在 best_effort 模式下标记为 success=False。"""
+
+        async def ok_coro():
+            return make_result("0.0")
+
+        async def fail_coro():
+            raise RuntimeError("boom")
+
+        results = await _run_best_effort(
+            [ok_coro(), fail_coro()],
+            ["0.0", "0.1"],
+            ["function", "llm"],
+        )
+
+        assert len(results) == 2
+        assert results[0].success is True
+        assert results[1].success is False
+        assert results[1].error == "boom"
+        assert results[1].task_type == "llm"
+        assert results[1].task_index == "0.1"
+
+
+# ---------------------------------------------------------------------------
+# Stream callback merging in _execute_one
+# ---------------------------------------------------------------------------
+
+
+class TestStreamCallbackMerging:
+    @pytest.mark.asyncio
+    async def test_harness_callback_used_when_task_has_none(self) -> None:
+        """Task 无 stream_callback 时使用 Harness 级回调。"""
+        harness_cb_called = []
+
+        def harness_cb(text: str) -> None:
+            harness_cb_called.append(text)
+
+        task = LLMTask(prompt="hello")
+        p = Parallel(tasks=[task])
+        kwargs = make_parallel_kwargs(
+            harness_stream_callback=harness_cb,
+        )
+
+        results = await execute_parallel(p, 0, [], **kwargs)
+
+        assert len(results) == 1
+        assert results[0].success is True
+        # harness_cb should have been called at least for separator
+        assert len(harness_cb_called) > 0
+
+    @pytest.mark.asyncio
+    async def test_task_callback_takes_priority(self) -> None:
+        """Task 有 stream_callback 时覆盖 Harness 级。"""
+        task_cb_called = []
+        harness_cb_called = []
+
+        def task_cb(text: str) -> None:
+            task_cb_called.append(text)
+
+        def harness_cb(text: str) -> None:
+            harness_cb_called.append(text)
+
+        task = LLMTask(prompt="hello", stream_callback=task_cb)
+        p = Parallel(tasks=[task])
+        kwargs = make_parallel_kwargs(
+            harness_stream_callback=harness_cb,
+        )
+
+        results = await execute_parallel(p, 0, [], **kwargs)
+        assert len(results) == 1
+        # Task-level callback used
+        assert len(task_cb_called) > 0
+        # Harness-level not used
+        assert len(harness_cb_called) == 0
+
+
+# ---------------------------------------------------------------------------
+# ShellTask dispatch in parallel
+# ---------------------------------------------------------------------------
+
+
+class TestParallelShellTask:
+    @pytest.mark.asyncio
+    async def test_shell_task_in_parallel(self) -> None:
+        """ShellTask 在 Parallel 中正常执行。"""
+        p = Parallel(tasks=[ShellTask(cmd="echo parallel_shell")])
+        kwargs = make_parallel_kwargs()
+
+        results = await execute_parallel(p, 0, [], **kwargs)
+        assert len(results) == 1
+        assert results[0].success is True
+        assert "parallel_shell" in results[0].output
+
+
+# ---------------------------------------------------------------------------
+# _task_type_str coverage
+# ---------------------------------------------------------------------------
+
+
+class TestTaskTypeStr:
+    def test_llm(self) -> None:
+        assert _task_type_str(LLMTask(prompt="x")) == "llm"
+
+    def test_function(self) -> None:
+        assert _task_type_str(FunctionTask(fn=lambda r: None)) == "function"
+
+    def test_shell(self) -> None:
+        assert _task_type_str(ShellTask(cmd="echo x")) == "shell"
+
+    def test_polling(self) -> None:
+        t = PollingTask(
+            submit_fn=lambda r: None,
+            poll_fn=lambda h: None,
+            success_condition=lambda r: True,
+        )
+        assert _task_type_str(t) == "polling"
+
+
+# ---------------------------------------------------------------------------
+# Best effort with Parallel block
+# ---------------------------------------------------------------------------
+
+
+class TestParallelBestEffort:
+    @pytest.mark.asyncio
+    async def test_best_effort_partial_failure(self) -> None:
+        """best_effort 模式下部分失败不抛异常。"""
+
+        def fail_fn(results):
+            raise RuntimeError("fail!")
+
+        p = Parallel(
+            tasks=[
+                FunctionTask(fn=lambda r: "ok"),
+                FunctionTask(fn=fail_fn, config=TaskConfig(max_retries=0)),
+            ],
+            error_policy="best_effort",
+        )
+        kwargs = make_parallel_kwargs()
+
+        results = await execute_parallel(p, 0, [], **kwargs)
+        assert len(results) == 2
+        successes = [r for r in results if r.success]
+        failures = [r for r in results if not r.success]
+        assert len(successes) == 1
+        assert len(failures) == 1

--- a/tests/unit/test_polling_edge_cases.py
+++ b/tests/unit/test_polling_edge_cases.py
@@ -1,0 +1,115 @@
+"""tests/unit/test_polling_edge_cases.py — PollingTask 边界情况覆盖。"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from pydantic import BaseModel
+
+from harness._internal.exceptions import TaskFailedError
+from harness._internal.polling import execute_polling
+from harness.task import PollingTask, TaskConfig
+
+
+def fast_config(max_retries: int = 0, timeout: float = 60) -> TaskConfig:
+    return TaskConfig(max_retries=max_retries, backoff_base=0.01, timeout=timeout)
+
+
+class TestPollingTimeout:
+    @pytest.mark.asyncio
+    async def test_config_timeout_triggers_asyncio_timeout(self) -> None:
+        """config.timeout 触发 asyncio.wait_for TimeoutError 路径。"""
+
+        def submit(results):
+            return "h"
+
+        async_sleep_called = False
+
+        def poll(handle):
+            return {"status": "pending"}
+
+        task = PollingTask(
+            submit_fn=submit,
+            poll_fn=poll,
+            success_condition=lambda r: r["status"] == "done",
+            poll_interval=0.001,
+            timeout=100,  # task.timeout 足够大
+        )
+        # 使用极小的 config.timeout 让 asyncio.wait_for 超时
+        with pytest.raises(TaskFailedError) as exc_info:
+            await execute_polling(
+                task, "0", [], "run-1",
+                harness_config=fast_config(max_retries=0, timeout=0.01),
+            )
+        assert "timed out" in exc_info.value.error
+
+
+class TestPollingSubmitError:
+    @pytest.mark.asyncio
+    async def test_submit_fn_raises(self) -> None:
+        """submit_fn 抛异常返回 (None, error_msg)，触发重试后最终失败。"""
+
+        def bad_submit(results):
+            raise RuntimeError("submit failed")
+
+        task = PollingTask(
+            submit_fn=bad_submit,
+            poll_fn=lambda h: None,
+            success_condition=lambda r: True,
+            poll_interval=0.001,
+            timeout=10,
+        )
+        with pytest.raises(TaskFailedError) as exc_info:
+            await execute_polling(
+                task, "0", [], "run-1",
+                harness_config=fast_config(max_retries=1),
+            )
+        assert "submit_fn raised" in exc_info.value.error
+
+
+class TestPollingPollError:
+    @pytest.mark.asyncio
+    async def test_poll_fn_raises(self) -> None:
+        """poll_fn 抛异常返回 (None, error_msg)。"""
+
+        def poll(handle):
+            raise ValueError("poll error")
+
+        task = PollingTask(
+            submit_fn=lambda r: "handle",
+            poll_fn=poll,
+            success_condition=lambda r: True,
+            poll_interval=0.001,
+            timeout=10,
+        )
+        with pytest.raises(TaskFailedError) as exc_info:
+            await execute_polling(
+                task, "0", [], "run-1",
+                harness_config=fast_config(max_retries=0),
+            )
+        assert "poll_fn raised" in exc_info.value.error
+
+
+class TestPollingOutputSchemaFailure:
+    @pytest.mark.asyncio
+    async def test_output_schema_validation_failure(self) -> None:
+        """output_schema 校验失败时返回错误，触发重试。"""
+
+        class Expected(BaseModel):
+            value: int
+
+        task = PollingTask(
+            submit_fn=lambda r: "h",
+            poll_fn=lambda h: {"bad": "data"},  # 不符合 schema
+            success_condition=lambda r: True,
+            poll_interval=0.001,
+            timeout=10,
+            output_schema=Expected,
+        )
+        with pytest.raises(TaskFailedError) as exc_info:
+            await execute_polling(
+                task, "0", [], "run-1",
+                harness_config=fast_config(max_retries=0),
+            )
+        assert "output_schema validation failed" in exc_info.value.error


### PR DESCRIPTION
## Summary

- Analyzed test coverage and identified 12 modules with significant gaps
- Added 6 new test files with 65 tests, improving overall coverage from **78% to 87%**
- All 349 tests pass

### Key coverage improvements

| Module | Before | After |
|--------|--------|-------|
| `_internal/exceptions.py` | 72% | **100%** |
| `_internal/polling.py` | 79% | **100%** |
| `runners/claude_cli.py` | 31% | **96%** |
| `runners/agent_leader.py` | 0% | **100%** |
| `_internal/executor.py` | 81% | **97%** |
| `_internal/parallel.py` | 79% | **96%** |

### New test files

- `test_classify_error.py` — All 11 branches of `_classify_error()` error classification
- `test_agent_leader.py` — Whitelist injection, prompt passthrough, default runner
- `test_claude_cli_runner.py` — Subprocess env cleanup, `_ensure_claude` caching, execute flow with mocked subprocess, `_terminate` SIGTERM/SIGKILL paths
- `test_polling_edge_cases.py` — `config.timeout`, `submit_fn`/`poll_fn` exceptions, `output_schema` validation failure
- `test_executor_edge_cases.py` — LLM timeout, FunctionTask `env_overrides` apply/restore/cleanup, ShellTask timeout+kill, `_emit_separator` error handling
- `test_parallel_edge_cases.py` — `all_or_nothing` cancellation, non-TaskFailedError wrapping, `best_effort` error marking, stream callback merging, ShellTask dispatch

## Test plan

- [x] All 349 tests pass (`uv run --extra dev pytest tests/ -v`)
- [x] Coverage report confirms improvements
- [x] No existing tests broken

https://claude.ai/code/session_01A3fL11WBL5ZD3osC9yB7T6