### PR TITLE
Fix 5 design issues: env race, env passthrough, concurrency limit, memory warning, SSE dedup

### DIFF
--- a/harness/_internal/executor.py
+++ b/harness/_internal/executor.py
@@ -33,6 +33,19 @@ from harness.task import (
 if TYPE_CHECKING:
     from harness.storage.base import StorageProtocol
 
+# 保护 os.environ 并发修改，防止 Parallel 内多个 FunctionTask 竞态。
+# 每个事件循环绑定独立 Lock，避免跨 loop 共享导致 RuntimeError。
+_env_locks: dict[int, asyncio.Lock] = {}
+
+
+def _get_env_lock() -> asyncio.Lock:
+    """获取当前事件循环绑定的 env_lock。"""
+    loop = asyncio.get_running_loop()
+    loop_id = id(loop)
+    if loop_id not in _env_locks:
+        _env_locks[loop_id] = asyncio.Lock()
+    return _env_locks[loop_id]
+
 
 def _effective_config(
     task_config: TaskConfig | None,
@@ -68,6 +81,7 @@ async def execute_llm_task(
     memory_injection: str,
     storage: "StorageProtocol | None" = None,
     is_new_session: bool = False,
+    env_overrides: dict[str, str] | None = None,
 ) -> Result:
     """执行单个 LLMTask，含重试逻辑。"""
     config = _effective_config(task.config, harness_config)
@@ -138,6 +152,7 @@ async def execute_llm_task(
                     output_schema_json=schema_json,
                     stream_callback=stream_cb,
                     raw_stream_callback=raw_cb,
+                    env_overrides=env_overrides,
                 ),
                 timeout=config.timeout,
             )
@@ -207,52 +222,55 @@ async def execute_function_task(
     attempt = 0
     last_error = ""
 
-    _orig_env: dict[str, str | None] = {}
-    if env_overrides:
-        for key, val in env_overrides.items():
-            _orig_env[key] = os.environ.get(key)
-            if val == "":
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = val
-
-    try:
-        while attempt <= config.max_retries:
-            try:
-                raw_output = task.fn(results)
-            except OutputSchemaError:
-                raise  # 直接向上抛，不重试
-            except Exception as e:
-                last_error = str(e)
-                attempt += 1
-                if attempt <= config.max_retries:
-                    wait = config.backoff_base ** (attempt - 1)
-                    await asyncio.sleep(wait)
-                continue
-
-            # output_schema 校验：失败抛 OutputSchemaError，不重试
-            if task.output_schema is not None:
-                if not isinstance(raw_output, task.output_schema):
-                    raise OutputSchemaError(task_index, task.output_schema, type(raw_output))
-
-            duration = time.monotonic() - start_time
-            return Result(
-                task_index=task_index,
-                task_type="function",
-                output=raw_output,
-                raw_text=None,
-                tokens_used=0,
-                duration_seconds=duration,
-                success=True,
-                error=None,
-            )
-    finally:
+    # env_overrides 用 asyncio.Lock 保护，防止 Parallel 内多个 FunctionTask 并发修改
+    # os.environ 导致竞态条件。Lock 确保同一时刻只有一个 FunctionTask 修改全局环境。
+    async with _get_env_lock():
+        _orig_env: dict[str, str | None] = {}
         if env_overrides:
-            for key, orig_val in _orig_env.items():
-                if orig_val is None:
+            for key, val in env_overrides.items():
+                _orig_env[key] = os.environ.get(key)
+                if val == "":
                     os.environ.pop(key, None)
                 else:
-                    os.environ[key] = orig_val
+                    os.environ[key] = val
+
+        try:
+            while attempt <= config.max_retries:
+                try:
+                    raw_output = task.fn(results)
+                except OutputSchemaError:
+                    raise  # 直接向上抛，不重试
+                except Exception as e:
+                    last_error = str(e)
+                    attempt += 1
+                    if attempt <= config.max_retries:
+                        wait = config.backoff_base ** (attempt - 1)
+                        await asyncio.sleep(wait)
+                    continue
+
+                # output_schema 校验：失败抛 OutputSchemaError，不重试
+                if task.output_schema is not None:
+                    if not isinstance(raw_output, task.output_schema):
+                        raise OutputSchemaError(task_index, task.output_schema, type(raw_output))
+
+                duration = time.monotonic() - start_time
+                return Result(
+                    task_index=task_index,
+                    task_type="function",
+                    output=raw_output,
+                    raw_text=None,
+                    tokens_used=0,
+                    duration_seconds=duration,
+                    success=True,
+                    error=None,
+                )
+        finally:
+            if env_overrides:
+                for key, orig_val in _orig_env.items():
+                    if orig_val is None:
+                        os.environ.pop(key, None)
+                    else:
+                        os.environ[key] = orig_val
 
     raise TaskFailedError(
         run_id, task_index, "function", last_error, partial_results=list(results)

--- a/harness/_internal/parallel.py
+++ b/harness/_internal/parallel.py
@@ -64,6 +64,11 @@ async def execute_parallel(
                 f"Found Parallel inside Parallel at index {outer_index}."
             )
 
+    # 并发限制：max_concurrency > 0 时使用 semaphore
+    semaphore: asyncio.Semaphore | None = None
+    if parallel.max_concurrency is not None and parallel.max_concurrency > 0:
+        semaphore = asyncio.Semaphore(parallel.max_concurrency)
+
     if parallel.error_policy == "all_or_nothing":
         return await _run_all_or_nothing_with_retry(
             parallel,
@@ -80,6 +85,7 @@ async def execute_parallel(
             harness_stream_callback=harness_stream_callback,
             harness_raw_stream_callback=harness_raw_stream_callback,
             env_overrides=env_overrides,
+            semaphore=semaphore,
         )
     else:
         # best_effort：一次性构建协程并等待全部完成
@@ -106,8 +112,16 @@ async def execute_parallel(
                 harness_raw_stream_callback=harness_raw_stream_callback,
                 env_overrides=env_overrides,
             )
-            coros.append(coro)
+            coros.append(_with_semaphore(coro, semaphore))
         return await _run_best_effort(coros, task_indices, task_types)
+
+
+async def _with_semaphore(coro: Any, semaphore: asyncio.Semaphore | None) -> Any:
+    """用 semaphore 包装协程，限制并发数。semaphore=None 时直接执行。"""
+    if semaphore is None:
+        return await coro
+    async with semaphore:
+        return await coro
 
 
 async def _run_all_or_nothing_with_retry(
@@ -126,6 +140,7 @@ async def _run_all_or_nothing_with_retry(
     harness_stream_callback: "Callable[[str], None] | None" = None,
     harness_raw_stream_callback: "Callable[[dict], None] | None" = None,
     env_overrides: "dict[str, str] | None" = None,
+    semaphore: asyncio.Semaphore | None = None,
 ) -> list[Result]:
     """all_or_nothing 策略：带整块重试上限（parallel.max_retries）的执行。
 
@@ -160,7 +175,7 @@ async def _run_all_or_nothing_with_retry(
                 harness_raw_stream_callback=harness_raw_stream_callback,
                 env_overrides=env_overrides,
             )
-            coros.append(coro)
+            coros.append(_with_semaphore(coro, semaphore))
 
         try:
             return await _run_all_or_nothing(coros, run_id, outer_index)
@@ -298,6 +313,7 @@ async def _execute_one(
             memory_injection=memory_injection,
             storage=storage,
             is_new_session=is_new_session,
+            env_overrides=env_overrides,
         )
     elif isinstance(task, FunctionTask):
         return await execute_function_task(

--- a/harness/harness.py
+++ b/harness/harness.py
@@ -399,6 +399,7 @@ class Harness:
                         memory_injection=memory_injection,
                         storage=self._storage,
                         is_new_session=session_manager.is_broken,
+                        env_overrides=self._env_overrides,
                     )
                     # 检查 memory_update
                     if (

--- a/harness/memory.py
+++ b/harness/memory.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from harness.storage.base import StorageProtocol
@@ -114,6 +117,15 @@ class Memory:
         try:
             current = memory_path.read_text(encoding="utf-8")
             if len(current) > threshold:
+                truncated_chars = len(current) - threshold
+                logger.warning(
+                    "memory file %s exceeded threshold (%d > %d chars), "
+                    "truncating oldest %d chars",
+                    memory_path,
+                    len(current),
+                    threshold,
+                    truncated_chars,
+                )
                 # 从末尾保留 threshold 个字符（保留最近内容）
                 memory_path.write_text(current[-threshold:], encoding="utf-8")
         except Exception:

--- a/harness/runners/_http.py
+++ b/harness/runners/_http.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import json
+from collections.abc import AsyncIterator
+
 import httpx
 
 
@@ -19,3 +22,20 @@ def raise_for_status(resp: httpx.Response, service: str) -> None:
         except Exception:
             detail = f"HTTP {resp.status_code}"
         raise RuntimeError(f"{service} API error {resp.status_code}: {detail}")
+
+
+async def iter_sse_events(lines: AsyncIterator[str]) -> AsyncIterator[dict]:
+    """从 SSE 行流中解析 JSON 事件，跳过非 data 行和 [DONE] 标记。
+
+    用于 OpenAI / Anthropic 等 SSE 流式 API 的共享解析逻辑。
+    """
+    async for line in lines:
+        if not line.startswith("data: "):
+            continue
+        data_str = line[6:]
+        if data_str == "[DONE]":
+            break
+        try:
+            yield json.loads(data_str)
+        except json.JSONDecodeError:
+            continue

--- a/harness/runners/anthropic.py
+++ b/harness/runners/anthropic.py
@@ -18,7 +18,7 @@ from typing import Callable
 
 import httpx
 
-from harness.runners._http import raise_for_status, safe_schema_name
+from harness.runners._http import iter_sse_events, raise_for_status, safe_schema_name
 from harness.runners.base import AbstractRunner, RunnerResult
 
 _API_URL = "https://api.anthropic.com/v1/messages"
@@ -168,14 +168,7 @@ class AnthropicRunner(AbstractRunner):
         async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
             async with client.stream("POST", _API_URL, json=stream_payload, headers=headers) as resp:
                 raise_for_status(resp, "Anthropic")
-                async for line in resp.aiter_lines():
-                    if not line.startswith("data: "):
-                        continue
-                    try:
-                        event = json.loads(line[6:])
-                    except json.JSONDecodeError:
-                        continue
-
+                async for event in iter_sse_events(resp.aiter_lines()):
                     etype = event.get("type")
 
                     if etype == "message_start":

--- a/harness/runners/claude_cli.py
+++ b/harness/runners/claude_cli.py
@@ -53,11 +53,20 @@ class ClaudeCliRunner(AbstractRunner):
         self._claude_path: str | None = None
         self._checked = False
 
-    def _get_subprocess_env(self) -> dict[str, str]:
-        """构建子进程环境变量，移除 Claude Code 相关变量。"""
+    def _get_subprocess_env(
+        self,
+        env_overrides: dict[str, str] | None = None,
+    ) -> dict[str, str]:
+        """构建子进程环境变量，移除 Claude Code 相关变量并应用覆写。"""
         env = dict(os.environ)
         for key in _ENV_VARS_TO_REMOVE:
             env.pop(key, None)
+        if env_overrides:
+            for key, val in env_overrides.items():
+                if val == "":
+                    env.pop(key, None)
+                else:
+                    env[key] = val
         return env
 
     async def _ensure_claude(self) -> str:
@@ -101,6 +110,7 @@ class ClaudeCliRunner(AbstractRunner):
         output_schema_json: str | None = None,
         stream_callback: Callable[[str], None] | None = None,
         raw_stream_callback: Callable[[dict], None] | None = None,
+        env_overrides: dict[str, str] | None = None,
         **kwargs: object,
     ) -> RunnerResult:
         """调用 Claude Code CLI 执行 prompt。
@@ -112,6 +122,7 @@ class ClaudeCliRunner(AbstractRunner):
             output_schema_json: JSON Schema 字符串，传给 --json-schema 参数。
             stream_callback: 接收解析后文本片段的回调。
             raw_stream_callback: 接收原始 event dict 的回调。
+            env_overrides: 额外环境变量覆写，空值表示删除。
         """
         claude_path = await self._ensure_claude()
 
@@ -136,7 +147,7 @@ class ClaudeCliRunner(AbstractRunner):
 
         args += ["-p", prompt]
 
-        env = self._get_subprocess_env()
+        env = self._get_subprocess_env(env_overrides)
 
         proc = await asyncio.create_subprocess_exec(
             *args,

--- a/harness/runners/openai.py
+++ b/harness/runners/openai.py
@@ -18,7 +18,7 @@ from typing import Callable
 
 import httpx
 
-from harness.runners._http import raise_for_status, safe_schema_name
+from harness.runners._http import iter_sse_events, raise_for_status, safe_schema_name
 from harness.runners.base import AbstractRunner, RunnerResult
 
 _DEFAULT_BASE_URL = "https://api.openai.com/v1"
@@ -154,16 +154,7 @@ class OpenAIRunner(AbstractRunner):
 
         async with client.stream("POST", url, json=stream_payload, headers=headers) as resp:
             raise_for_status(resp, "OpenAI")
-            async for line in resp.aiter_lines():
-                if not line.startswith("data: "):
-                    continue
-                data_str = line[6:]
-                if data_str == "[DONE]":
-                    break
-                try:
-                    chunk = json.loads(data_str)
-                except json.JSONDecodeError:
-                    continue
+            async for chunk in iter_sse_events(resp.aiter_lines()):
                 choices = chunk.get("choices") or []
                 if choices:
                     delta = choices[0].get("delta") or {}

--- a/harness/task.py
+++ b/harness/task.py
@@ -172,6 +172,7 @@ class Parallel(BaseTask):
     )
     error_policy: Literal["all_or_nothing", "best_effort"] = "all_or_nothing"
     max_retries: int = 2
+    max_concurrency: int | None = None  # None = 无限制，>0 = semaphore 限制并发数
 
     def __post_init__(self) -> None:
         # 用户写 Parallel([task_a, task_b]) 时，list 会落到继承自 BaseTask 的

--- a/tests/unit/test_design_fixes.py
+++ b/tests/unit/test_design_fixes.py
@@ -1,0 +1,285 @@
+"""tests/unit/test_design_fixes.py — 设计优化相关测试。"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from harness._internal.exceptions import TaskFailedError
+from harness._internal.executor import _get_env_lock, execute_function_task
+from harness._internal.parallel import _with_semaphore, execute_parallel
+from harness._internal.session import SessionManager
+from harness.runners.base import AbstractRunner, RunnerResult
+from harness.task import FunctionTask, LLMTask, Parallel, ShellTask, TaskConfig
+
+
+# ---------------------------------------------------------------------------
+# Fix #1: env_overrides 竞态保护（asyncio.Lock）
+# ---------------------------------------------------------------------------
+
+
+class TestEnvLockProtection:
+    @pytest.mark.asyncio
+    async def test_concurrent_env_overrides_no_race(self) -> None:
+        """并发 FunctionTask 使用不同 env_overrides 不互相干扰。"""
+        captured_a = {}
+        captured_b = {}
+
+        def fn_a(results):
+            captured_a["val"] = os.environ.get("HARNESS_RACE_TEST")
+            return "a"
+
+        def fn_b(results):
+            captured_b["val"] = os.environ.get("HARNESS_RACE_TEST")
+            return "b"
+
+        task_a = FunctionTask(fn=fn_a)
+        task_b = FunctionTask(fn=fn_b)
+
+        # 并发执行，各自带不同的 env_overrides
+        result_a, result_b = await asyncio.gather(
+            execute_function_task(
+                task_a, "0", [], "run-1",
+                harness_config=None,
+                env_overrides={"HARNESS_RACE_TEST": "value_a"},
+            ),
+            execute_function_task(
+                task_b, "0", [], "run-1",
+                harness_config=None,
+                env_overrides={"HARNESS_RACE_TEST": "value_b"},
+            ),
+        )
+
+        # Lock 序列化了执行：每个 fn 看到的值应该是自己的 override
+        assert captured_a["val"] == "value_a"
+        assert captured_b["val"] == "value_b"
+        # 执行后环境变量已恢复
+        assert os.environ.get("HARNESS_RACE_TEST") is None
+
+    @pytest.mark.asyncio
+    async def test_env_lock_per_event_loop(self) -> None:
+        """_get_env_lock 返回当前事件循环绑定的 Lock。"""
+        lock = _get_env_lock()
+        assert isinstance(lock, asyncio.Lock)
+        # 同一循环内应返回同一个 Lock
+        assert _get_env_lock() is lock
+
+
+# ---------------------------------------------------------------------------
+# Fix #2: ClaudeCliRunner env_overrides 透传
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeCliRunnerEnvOverrides:
+    def test_get_subprocess_env_with_overrides(self) -> None:
+        from harness.runners.claude_cli import ClaudeCliRunner
+
+        runner = ClaudeCliRunner()
+        with patch.dict(os.environ, {"PATH": "/usr/bin", "MY_VAR": "old"}, clear=False):
+            env = runner._get_subprocess_env(
+                env_overrides={"MY_VAR": "new", "EXTRA": "added"}
+            )
+            assert env["MY_VAR"] == "new"
+            assert env["EXTRA"] == "added"
+
+    def test_get_subprocess_env_remove_via_empty(self) -> None:
+        from harness.runners.claude_cli import ClaudeCliRunner
+
+        runner = ClaudeCliRunner()
+        with patch.dict(os.environ, {"REMOVE_ME": "val"}, clear=False):
+            env = runner._get_subprocess_env(
+                env_overrides={"REMOVE_ME": ""}
+            )
+            assert "REMOVE_ME" not in env
+
+    def test_get_subprocess_env_none_overrides(self) -> None:
+        from harness.runners.claude_cli import ClaudeCliRunner
+
+        runner = ClaudeCliRunner()
+        env1 = runner._get_subprocess_env()
+        env2 = runner._get_subprocess_env(env_overrides=None)
+        # 都不应该报错，结果等价
+        assert "PATH" in env1
+        assert "PATH" in env2
+
+
+# ---------------------------------------------------------------------------
+# Fix #3: Parallel max_concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestParallelMaxConcurrency:
+    @pytest.mark.asyncio
+    async def test_max_concurrency_limits_parallel_execution(self) -> None:
+        """max_concurrency=1 确保任务串行执行。"""
+        execution_order = []
+
+        def fn_factory(name):
+            def fn(results):
+                execution_order.append(f"{name}_start")
+                execution_order.append(f"{name}_end")
+                return name
+            return fn
+
+        tasks = [
+            FunctionTask(fn=fn_factory("a")),
+            FunctionTask(fn=fn_factory("b")),
+            FunctionTask(fn=fn_factory("c")),
+        ]
+        p = Parallel(tasks=tasks, max_concurrency=1)
+        kwargs = dict(
+            run_id="run-1",
+            harness_system_prompt="",
+            harness_runner=MockRunner(),
+            harness_config=None,
+            session_manager=SessionManager(),
+            memory_injection="",
+            storage=None,
+            is_new_session=False,
+        )
+
+        results = await execute_parallel(p, 0, [], **kwargs)
+        assert all(r.success for r in results)
+
+        # max_concurrency=1 时任务串行，不会交错
+        for i in range(0, len(execution_order), 2):
+            name = execution_order[i].replace("_start", "")
+            assert execution_order[i] == f"{name}_start"
+            assert execution_order[i + 1] == f"{name}_end"
+
+    @pytest.mark.asyncio
+    async def test_max_concurrency_none_no_limit(self) -> None:
+        """max_concurrency=None 时无限制（默认行为）。"""
+        tasks = [
+            FunctionTask(fn=lambda r: "a"),
+            FunctionTask(fn=lambda r: "b"),
+        ]
+        p = Parallel(tasks=tasks, max_concurrency=None)
+        kwargs = dict(
+            run_id="run-1",
+            harness_system_prompt="",
+            harness_runner=MockRunner(),
+            harness_config=None,
+            session_manager=SessionManager(),
+            memory_injection="",
+            storage=None,
+            is_new_session=False,
+        )
+        results = await execute_parallel(p, 0, [], **kwargs)
+        assert len(results) == 2
+        assert all(r.success for r in results)
+
+    @pytest.mark.asyncio
+    async def test_with_semaphore_none(self) -> None:
+        """semaphore=None 时直接执行协程。"""
+
+        async def coro():
+            return 42
+
+        result = await _with_semaphore(coro(), None)
+        assert result == 42
+
+    @pytest.mark.asyncio
+    async def test_with_semaphore_limits(self) -> None:
+        """semaphore 正常限制并发。"""
+        sem = asyncio.Semaphore(1)
+
+        async def coro():
+            return "ok"
+
+        result = await _with_semaphore(coro(), sem)
+        assert result == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Fix #4: Memory truncation warning
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryTruncationWarning:
+    def test_truncation_logs_warning(self, tmp_path, caplog) -> None:
+        import logging
+        from harness.memory import Memory
+
+        mem = Memory(max_tokens=100)
+        mem_file = tmp_path / ".harness" / "memory.md"
+
+        # 写入大量内容使其超过阈值（80 chars）
+        mem.write_memory_update(tmp_path, "x" * 50)
+        mem.write_memory_update(tmp_path, "y" * 50)
+
+        with caplog.at_level(logging.WARNING, logger="harness.memory"):
+            mem.write_memory_update(tmp_path, "z" * 50)
+
+        assert "truncating" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Fix #5: shared SSE parser
+# ---------------------------------------------------------------------------
+
+
+class TestIterSseEvents:
+    @pytest.mark.asyncio
+    async def test_parses_data_lines(self) -> None:
+        from harness.runners._http import iter_sse_events
+
+        async def lines():
+            yield 'data: {"key": "value"}'
+            yield 'data: {"key2": "value2"}'
+
+        events = [e async for e in iter_sse_events(lines())]
+        assert len(events) == 2
+        assert events[0]["key"] == "value"
+        assert events[1]["key2"] == "value2"
+
+    @pytest.mark.asyncio
+    async def test_skips_non_data_lines(self) -> None:
+        from harness.runners._http import iter_sse_events
+
+        async def lines():
+            yield "event: message"
+            yield ": comment"
+            yield ""
+            yield 'data: {"ok": true}'
+
+        events = [e async for e in iter_sse_events(lines())]
+        assert len(events) == 1
+
+    @pytest.mark.asyncio
+    async def test_stops_at_done(self) -> None:
+        from harness.runners._http import iter_sse_events
+
+        async def lines():
+            yield 'data: {"first": true}'
+            yield "data: [DONE]"
+            yield 'data: {"should_not_appear": true}'
+
+        events = [e async for e in iter_sse_events(lines())]
+        assert len(events) == 1
+        assert events[0]["first"] is True
+
+    @pytest.mark.asyncio
+    async def test_skips_invalid_json(self) -> None:
+        from harness.runners._http import iter_sse_events
+
+        async def lines():
+            yield "data: not-json"
+            yield 'data: {"valid": true}'
+
+        events = [e async for e in iter_sse_events(lines())]
+        assert len(events) == 1
+        assert events[0]["valid"] is True
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+class MockRunner(AbstractRunner):
+    async def execute(self, prompt, *, system_prompt, session_id, **kwargs) -> RunnerResult:
+        return RunnerResult(text="ok", tokens_used=0, session_id=None)


### PR DESCRIPTION
## Summary

- Fix env_overrides race condition in FunctionTask with asyncio.Lock (P0)
- Pass env_overrides through to ClaudeCliRunner subprocess (P0)
- Add `Parallel(max_concurrency=N)` semaphore-based concurrency limit (P1)
- Add warning log when Memory file is truncated (P2)
- Extract shared `iter_sse_events()` SSE parser for OpenAI/Anthropic runners (P2)

## Test plan

- [x] All 363 tests pass
- [x] 14 new tests in `test_design_fixes.py` covering all changes

https://claude.ai/code/session_01A3fL11WBL5ZD3osC9yB7T6