### PR TITLE
fix: prevent Claude CLI subprocess hang from unavailable MCP servers

### DIFF
--- a/examples/research/pipeline.py
+++ b/examples/research/pipeline.py
@@ -64,6 +64,8 @@ def _progress_handler(e) -> None:
     """Discussion 进度回调。"""
     if e.event == "streaming":
         print(e.content or "", end="", flush=True)
+    elif e.event == "phase":
+        print(f"\n  [{e.agent_name}] {e.content}", flush=True)
     elif e.event == "start":
         print(f"\n  [{e.event}] {e.agent_name}", flush=True)
     elif e.event == "complete":

--- a/harness/_internal/discussion.py
+++ b/harness/_internal/discussion.py
@@ -285,6 +285,15 @@ async def _execute_agent_turn(
 
         try:
             # ── Phase 1: 自由文本分析 ──
+            if discussion.progress_callback:
+                discussion.progress_callback(
+                    DiscussionProgressEvent(
+                        event="phase",
+                        round=round_num,
+                        agent_name=agent.name,
+                        content="Phase 1: 自由文本分析",
+                    )
+                )
             phase1_result = await asyncio.wait_for(
                 runner.execute(
                     prompt_text,
@@ -310,6 +319,15 @@ async def _execute_agent_turn(
             total_tokens = phase1_result.tokens_used
 
             # ── Phase 2: 立场提取 ──
+            if discussion.progress_callback:
+                discussion.progress_callback(
+                    DiscussionProgressEvent(
+                        event="phase",
+                        round=round_num,
+                        agent_name=agent.name,
+                        content="Phase 2: 立场提取",
+                    )
+                )
             prev_position = ctx.my_position
             extraction_prompt = _build_extraction_prompt(
                 response_text, discussion.position_schema,

--- a/harness/runners/claude_cli.py
+++ b/harness/runners/claude_cli.py
@@ -43,13 +43,18 @@ class ClaudeCliRunner(AbstractRunner):
 
     Args:
         permission_mode: Claude Code 权限模式，默认 BYPASS（无人值守自动化）。
+        disable_mcp: 禁用子进程的 MCP server 连接。默认 True，
+            防止继承父进程（如 Claude Code 交互 session）的 MCP 配置
+            导致子进程因 MCP server 不可达而挂起。
     """
 
     def __init__(
         self,
         permission_mode: PermissionMode = PermissionMode.BYPASS,
+        disable_mcp: bool = True,
     ) -> None:
         self.permission_mode = permission_mode
+        self.disable_mcp = disable_mcp
         self._claude_path: str | None = None
         self._checked = False
 
@@ -135,6 +140,11 @@ class ClaudeCliRunner(AbstractRunner):
             "stream-json",
             "--include-partial-messages",
         ]
+
+        if self.disable_mcp:
+            # 使用 --strict-mcp-config 覆盖所有 MCP 配置（~/.claude.json 等），
+            # 防止子进程继承父进程的 MCP server 连接导致挂起。
+            args += ["--strict-mcp-config"]
 
         if system_prompt:
             args += ["--system-prompt", system_prompt]

--- a/tests/unit/test_claude_cli_runner.py
+++ b/tests/unit/test_claude_cli_runner.py
@@ -20,6 +20,16 @@ class TestPermissionMode:
         assert PermissionMode.PLAN == "plan"
 
 
+class TestDisableMcp:
+    def test_default_disable_mcp(self) -> None:
+        runner = ClaudeCliRunner()
+        assert runner.disable_mcp is True
+
+    def test_explicit_disable_mcp_false(self) -> None:
+        runner = ClaudeCliRunner(disable_mcp=False)
+        assert runner.disable_mcp is False
+
+
 class TestGetSubprocessEnv:
     def test_removes_claude_vars(self) -> None:
         runner = ClaudeCliRunner()
@@ -137,6 +147,64 @@ class TestExecute:
 
         assert result.text == "hello world"
         assert result.session_id == "sess-1"
+
+    @pytest.mark.asyncio
+    async def test_strict_mcp_config_flag(self) -> None:
+        """disable_mcp=True（默认）时添加 --strict-mcp-config。"""
+        runner = ClaudeCliRunner()
+        runner._checked = True
+        runner._claude_path = "/usr/bin/claude"
+
+        captured_args = []
+
+        async def mock_create(*args, **kwargs):
+            captured_args.extend(args)
+            mock_stdout = AsyncMock()
+            mock_stdout.__aiter__ = lambda self: self
+            mock_stdout.__anext__ = AsyncMock(side_effect=StopAsyncIteration())
+            mock_stderr = AsyncMock()
+            mock_stderr.read = AsyncMock(return_value=b"")
+            proc = AsyncMock()
+            proc.stdout = mock_stdout
+            proc.stderr = mock_stderr
+            proc.wait = AsyncMock(return_value=0)
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_create), \
+             patch.object(runner, "_get_subprocess_env", return_value={}):
+            await runner.execute("prompt", system_prompt="", session_id=None)
+
+        assert "--strict-mcp-config" in captured_args
+
+    @pytest.mark.asyncio
+    async def test_no_strict_mcp_config_when_disabled(self) -> None:
+        """disable_mcp=False 时不添加 --strict-mcp-config。"""
+        runner = ClaudeCliRunner(disable_mcp=False)
+        runner._checked = True
+        runner._claude_path = "/usr/bin/claude"
+
+        captured_args = []
+
+        async def mock_create(*args, **kwargs):
+            captured_args.extend(args)
+            mock_stdout = AsyncMock()
+            mock_stdout.__aiter__ = lambda self: self
+            mock_stdout.__anext__ = AsyncMock(side_effect=StopAsyncIteration())
+            mock_stderr = AsyncMock()
+            mock_stderr.read = AsyncMock(return_value=b"")
+            proc = AsyncMock()
+            proc.stdout = mock_stdout
+            proc.stderr = mock_stderr
+            proc.wait = AsyncMock(return_value=0)
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_create), \
+             patch.object(runner, "_get_subprocess_env", return_value={}):
+            await runner.execute("prompt", system_prompt="", session_id=None)
+
+        assert "--strict-mcp-config" not in captured_args
 
     @pytest.mark.asyncio
     async def test_session_id_passed_as_resume(self) -> None:

--- a/tests/unit/test_discussion.py
+++ b/tests/unit/test_discussion.py
@@ -663,7 +663,7 @@ class TestExecuteDiscussion:
 
     @pytest.mark.asyncio
     async def test_progress_callback(self) -> None:
-        """进度回调正常调用。"""
+        """进度回调正常调用，包含 phase 事件。"""
         events: list[DiscussionProgressEvent] = []
 
         runner = MockRunner(
@@ -687,11 +687,19 @@ class TestExecuteDiscussion:
             harness_config=TaskConfig(),
         )
 
-        assert len(events) == 2
+        event_types = [e.event for e in events]
+        assert event_types == ["start", "phase", "phase", "complete"]
         assert events[0].event == "start"
         assert events[0].agent_name == "a"
-        assert events[1].event == "complete"
-        assert events[1].content == "ok analysis"
+        # Phase 1 event
+        assert events[1].event == "phase"
+        assert "Phase 1" in events[1].content
+        # Phase 2 event
+        assert events[2].event == "phase"
+        assert "Phase 2" in events[2].content
+        # Complete event
+        assert events[3].event == "complete"
+        assert events[3].content == "ok analysis"
 
     @pytest.mark.asyncio
     async def test_agent_fallback_harness_runner(self) -> None:


### PR DESCRIPTION
## Summary

- **Root cause fix**: `ClaudeCliRunner` 默认传递 `--strict-mcp-config` 给子进程，防止继承父进程 MCP 配置导致长时间挂起
- **Visibility improvement**: Discussion `progress_callback` 新增 `"phase"` 事件，Phase 1/Phase 2 切换时输出状态

## Test plan

- [x] 660 tests pass（包括新增 4 个单元测试）
- [x] `test_strict_mcp_config_flag` — 验证默认传递 `--strict-mcp-config`
- [x] `test_no_strict_mcp_config_when_disabled` — 验证 `disable_mcp=False` 时不传递
- [x] `test_progress_callback` — 验证 `"phase"` 事件顺序

🤖 Generated with [Claude Code](https://claude.ai/code)